### PR TITLE
Add ansible.limit to reference correct machines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,5 +16,6 @@ Vagrant.configure("2") do |config|
         ansible.playbook        = "provisioning/playbook.yml"
         ansible.inventory_path  = "provisioning/ansible_hosts"
         ansible.verbose         = "vv"
+        ansible.limit           = "all"
     end
 end


### PR DESCRIPTION
Breaking change in vagrant which prevents Ansible from working if machine names don't match, this fixes that problem.
